### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:8 AS base
+FROM node:8-stretch AS base
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
-RUN echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.6 main" | tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+RUN echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/3.6 main" | tee /etc/apt/sources.list.d/mongodb-org-3.6.list
 RUN apt-get update -qq && \
     apt-get upgrade -qqy && \
     apt-get install -qqy \


### PR DESCRIPTION
The operating system is set to stretch, this way we avoid errors when changing the base of node:8

Fix https://github.com/microrealestate/microrealestate/issues/5
